### PR TITLE
Rely on `autopub check` to halt Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,11 @@ install:
   - pip install poetry
   - poetry install
 script: pytest
-after_success:
+before_deploy:
   - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then travis_terminate 0; fi'
+  - pip install --pre autopub
+  - autopub check
+  - pip install githubrelease
   - >-
     openssl aes-256-cbc
     -K $encrypted_6cb2737f72a1_key
@@ -18,17 +21,11 @@ after_success:
   - chmod 600 .github/deploy_key
   - eval $(ssh-agent -s)
   - ssh-add .github/deploy_key
-before_deploy:
-  - pip install --pre autopub
-  - pip install githubrelease
 deploy:
-  env:
-    - HAS_RELEASE=$(autopub check)
   provider: script
   script: autopub deploy
   on:
     branch: master
-    condition: "$HAS_RELEASE = true"
 env:
   global:
     - PYPI_USERNAME=autopub


### PR DESCRIPTION
Instead of having `autopub check` output "true" (just for Travis) when a
release file is found, setting a HAS_RELEASE env var with that value,
and then running the `deploy` stage only if that var is true, this new
flow depends on `autopub check` sending `travis_terminate 0` instead.

This also dispenses with the `after_success` stage, instead putting all
pre-deployment steps in the `before_deploy` stage.