### PR TITLE
Use Travis v0 conditions to use `travis_terminate`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+conditions: v0
 dist: xenial
 language: python
 python:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Use Travis v0 conditions, where `travis_terminate` command is allegedly available.


### PR DESCRIPTION
The `travis_terminate` command is allegedly present in the deprecated v0
conditions. Otherwise results in "No such file or directory" error.
https://docs.travis-ci.com/user/conditions-v0